### PR TITLE
Atomic rating changes to prevent elo drift by not changing their rating until you interpret what their old rating means for your new one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+.idea

--- a/src/main/java/com/joshuasnider/jelo/Match.java
+++ b/src/main/java/com/joshuasnider/jelo/Match.java
@@ -7,8 +7,8 @@ package com.joshuasnider.jelo;
 public class Match<E>
 {
     private Outcomes result;
-    private Player<E> first;
-    private Player<E> second;
+    private Player<E> winner;
+    private Player<E> loser;
 
     public enum Outcomes {
       ePlayer_One_Won,
@@ -19,11 +19,19 @@ public class Match<E>
     public Match(Player<E> firstPlayer, Player<E> secondPlayer,
         Outcomes result)
     {
-      first = firstPlayer;
-      second = secondPlayer;
+        if(result == Outcomes.ePlayer_One_Won){
+            winner = firstPlayer;
+            loser = secondPlayer;
+        }
+        if(result == Outcomes.ePlayer_Two_Won){
+            loser = firstPlayer;
+            winner = secondPlayer;
+        }
       this.result = result;
-      firstPlayer.addMatch(this);
-      secondPlayer.addMatch(this);
+      winner.addMatch(this);
+      loser.addMatch(this);
+      winner.commitLatestMatch();
+      loser.commitLatestMatch();
     }
 
     /**
@@ -32,11 +40,11 @@ public class Match<E>
      */
     public Player<E> getOpponent(Player<E> player) {
       Player<E> opponent = null;
-      if (player == first) {
-        opponent = second;
+      if (player == winner) {
+        opponent = loser;
       }
-      else if (player == second) {
-        opponent = first;
+      else if (player == loser) {
+        opponent = winner;
       }
       else {
         throw new IllegalArgumentException(
@@ -51,35 +59,17 @@ public class Match<E>
      * @throws IllegalArgumentException if player was not in this match.
      */
     public double getScore(Player<E> player) {
-      double score = 0.5;
-      if (player == first) {
-        switch (result) {
-          case ePlayer_One_Won:
-            score = 1.0;
-            break;
-          case ePlayer_Two_Won:
-            score = 0.0;
-            break;
-          case eDraw:
-            score = .5;
-            break;
+        if(result == Outcomes.eDraw &&
+                (player == winner || player == loser)){
+            return 0.5;
         }
-      } else if (player == second) {
-        switch (result) {
-          case ePlayer_One_Won:
-            score = 0.0;
-            break;
-          case ePlayer_Two_Won:
-            score = 1.0;
-            break;
-          case eDraw:
-            score = .5;
-            break;
-        }
+      if (player == winner) {
+          return 1.0;
+      } else if (player == loser) {
+        return 0.0;
       } else {
         throw new IllegalArgumentException(
           "Given player was not in this match.");
       }
-      return score;
     }
 }

--- a/src/main/java/com/joshuasnider/jelo/Player.java
+++ b/src/main/java/com/joshuasnider/jelo/Player.java
@@ -12,8 +12,9 @@ public class Player<E>
   private int rating;
   private E id;
   private List<Match<E>> matches;
+  private double ratingDelta = 0.0;
 
-  /**
+    /**
    * Create a player with the given ID.
    */
   public Player(E id) {
@@ -24,13 +25,18 @@ public class Player<E>
 
   /**
    * Record us playing in a match. Change our score to reflect playing
-   *  an opponent.
+   *  an opponent. Must be committed after adding all simultaneous match participants
    * @see <a href="https://en.wikipedia.org/wiki/Elo_rating_system#Mathematical_details">Source</a>
    */
   public void addMatch(Match<E> match) {
     matches.add(match);
     double k = getK();
-    rating += k * (match.getScore(this) - getWinOdds(match.getOpponent(this)));
+    ratingDelta += k * (match.getScore(this) - getWinOdds(match.getOpponent(this)));
+  }
+
+  public void commitLatestMatch(){
+      rating+=ratingDelta;
+      ratingDelta = 0.0;
   }
 
   /**


### PR DESCRIPTION
Thanks for the head start but there were some bugs when I was modifying your implementation, this test was failing and I knew I needed to do some surgery.

My project isn't open-source right now but I wanted to pay the code forward for now.

This test was failing until I made similar changes to my code.

```@Test
    public void homeAwayEqual(){
        Rating<String> wh = new Rating<>("ha");
        Rating<String> la = new Rating<>("aa");
        new Match<>(wh, la, 3.5);

        Rating<String> lh = new Rating<>("hb");
        Rating<String> wa = new Rating<>("ab");
        new Match<>(lh, wa, -3.5);
        System.out.println(Math.abs(wh.getRating()-wa.getRating()));
        System.out.println(Math.abs(lh.getRating()-la.getRating()));
        assert Math.abs(wh.getRating()-wa.getRating()) < 0.01;
        assert Math.abs(lh.getRating()-la.getRating()) < 0.01;
    }```